### PR TITLE
created layout for CreateHouseholdScreen

### DIFF
--- a/screens/CreateHouseholdScreen.tsx
+++ b/screens/CreateHouseholdScreen.tsx
@@ -1,21 +1,94 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import React from "react";
-import { View, Text, Button } from "react-native";
+import { StyleSheet, View } from "react-native";
+import { Button, Surface, Text, TextInput, useTheme } from "react-native-paper";
 import { RootStackParamList } from "../navigation/RootNavigator";
 
 type Props = NativeStackScreenProps<RootStackParamList, "Profile">;
 
 const CreateHouseholdScreen = ({ navigation }: Props) => {
   return (
-    <View>
-      <Text>CREATE HOUSEHOLD SCREEN</Text>
-      <Text>Handlebar Fil</Text>
-      <Button
-        title="tryck mig"
-        onPress={() => navigation.navigate("Profile")}
+    <View style={styles.root}>
+      <Text style={styles.title}>Hushållets namn</Text>
+      {/* TODO: Use Formic and Yup.  */}
+      <TextInput 
+        mode="outlined"
+        theme={{ roundness: 10 }}
+        style={styles.inputField}
       />
+      <Text style={styles.title}>Hushållets kod</Text>
+      <Surface style={styles.codeBox}>
+        {/* TODO: Add implementation of random code-generator for householdcode and show generated code */}
+        <Text style={styles.code}>Kod</Text>
+      </Surface>
+      <View style={styles.buttonContainer}>
+        <Surface style={styles.buttonBox}>
+          <Button
+            icon="plus-circle-outline"
+            labelStyle={{ fontSize: 25 }}
+            mode="text"
+            uppercase={false}
+            color={"#000"}
+            style={styles.confirmButton}
+            onPress={() => console.log("Pressed")} //TODO: Create a new household object, direct user to the newly created household-view
+          >
+            <Text style={styles.confirmText}>Bekräfta</Text>
+          </Button>
+        </Surface>
+      </View>
     </View>
   );
 };
 
 export default CreateHouseholdScreen;
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    paddingHorizontal: 11,
+    paddingTop: 11,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "bold",
+    marginTop: 12,
+    marginBottom: 5,
+  },
+  inputField: {
+    backgroundColor: "#fff",
+  },
+  codeBox: {
+    marginTop: 7,
+    paddingLeft: 17,
+    justifyContent: "center",
+    borderRadius: 10,
+    height: 58,
+    borderColor: "#000",
+    elevation: 3,
+  },
+  code: {
+    fontSize: 16,
+  },
+  buttonContainer: {
+    flex: 1,
+    bottom: 15,
+    justifyContent: "flex-end",
+    alignItems: "center",
+  },
+  buttonBox: {
+    justifyContent: "center",
+    padding: 0,
+    borderRadius: 100,
+    width: 160,
+    borderColor: "#000",
+    elevation: 3,
+  },
+  confirmButton: {
+    padding: 10,
+  },
+  confirmText: {
+    fontSize: 18,
+    fontWeight: "bold",
+    letterSpacing: 0.1,
+  },
+});

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -4,7 +4,7 @@ import { View, Text, Button, StyleSheet } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { RootStackParamList } from "../navigation/RootNavigator";
 
-type Props = NativeStackScreenProps<RootStackParamList, "Profile">;
+type Props = NativeStackScreenProps<RootStackParamList, "CreateHousehold">;
 
 const LoginScreen = ({ navigation }: Props) => {
   return (
@@ -13,7 +13,11 @@ const LoginScreen = ({ navigation }: Props) => {
       <Button
         title="tryck mig"
         onPress={() => navigation.navigate("Profile")}
-      /> 
+      />
+      <Button
+        title="Create household"
+        onPress={() => navigation.navigate("CreateHousehold")}
+      />
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
close #24 

Created layout for the CreateHouseholdScreen. Added button in LoginScreen for easy access to his screen. This will be removed later on.

Design issues:
- Wanted a shadow for the input-field, but could not find a easy way to implement it.
- The border-color for the input field has to be changed. I suppose the color will depend on formik and yup later on.
- The confirm button gets pushed up by the keyboard on Android when pressing the input field for household name (someone with an Iphone, please check if it is the same for iOS).

**NOTE**: No implementation of logic is addressed in this issue and branch. See other issues for more info regarding logic implementations for this screen.
#33 #34 #35

![246380900_673167870593934_8997666971562961309_n](https://user-images.githubusercontent.com/71378960/137790238-f4ca1fcc-9ea4-4e82-9a90-5a24ce259878.jpg)


