### PR TITLE
fixed TouchableRipple design

### DIFF
--- a/components/ChoreSurface.tsx
+++ b/components/ChoreSurface.tsx
@@ -85,6 +85,7 @@ const ChoreSurface = ({ navigation, choreId, isEditPressed }: Props) => {
     <View>
       <Surface style={stylesLocal.surface}>
         <TouchableRipple
+        borderless={true}
           style={stylesLocal.chip}
           onPress={() => {
             navigation.navigate("ChoreDescriptionModalScreen", choreId);

--- a/components/HouseholdSurface.tsx
+++ b/components/HouseholdSurface.tsx
@@ -29,15 +29,16 @@ const HouseholdSurface: FC<Props> = ({
     <View>
       <Surface style={styles.surface}>
         <TouchableRipple
+        borderless={true}
           style={styles.chip}
           onPress={() => {
             onChange(householdObject.id);
           }}
         >
-          <Surface style={styles.innerContainer}>
             <Text key={householdObject.id} style={styles.surfaceText}>
               {householdObject.name}
             </Text>
+            </TouchableRipple>
             {isAdmin ? (
               <IconButton
                 icon="pencil-outline"
@@ -47,8 +48,6 @@ const HouseholdSurface: FC<Props> = ({
             ) : (
               <View />
             )}
-          </Surface>
-        </TouchableRipple>
       </Surface>
     </View>
   );
@@ -60,29 +59,26 @@ const styles = StyleSheet.create({
   surface: {
     height: "auto",
     borderRadius: 10,
-    width: "100%",
-    alignItems: "flex-start",
-    justifyContent: "center",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-evenly",
     backgroundColor: "white",
     elevation: 4,
     marginVertical: 5,
   },
   surfaceText: {
     flex: 1,
-    width: "100%",
-    height: "100%",
     fontSize: 18,
     fontWeight: "bold",
-    alignItems: "flex-start",
-    alignSelf: "flex-start",
   },
   chip: {
-    justifyContent: "space-between",
-    width: "100%",
+    flex: 1,
     padding: 10,
     backgroundColor: "white",
     height: 50,
     borderRadius: 10,
+    justifyContent: "center",
+
   },
   innerContainer: {
     flex: 1,


### PR DESCRIPTION
closes #110 

- fixed that strange TouchableRipple shadow.
- added borderless={true} to TouchableRipple on HouseholdSurface and ChoreSurface. Now the shadow outside the box while press disappeared :) 👯‍♀️ 