### PR TITLE
all screens use BigThemedButton and same margin

### DIFF
--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -6,6 +6,7 @@ import { Button as NPbutton } from "react-native-paper";
 import ThemedTextInput from "./ThemedTextInput";
 import { User } from "../interfaces/user";
 import { useAppSelector } from "../store/store";
+import BigThemedButton from "./BigThemedButton";
 
 interface Props {
   onSubmit: (user: User) => void;
@@ -57,14 +58,13 @@ const LoginForm: FC<Props> = ({ onSubmit }: Props) => {
               helperText={touched.password && errors.password}
             />
           </View>
-          <NPbutton
-            icon="account-key-outline"
-            mode="contained"
-            style={styles.NPbutton}
+          <View style={styles.NPButtonContainer}>
+          <BigThemedButton
+            typeOfIcon="account-key-outline"
+            buttonText="Logga in"
             onPress={() => handleSubmit()}
-          >
-            Logga in
-          </NPbutton>
+          />
+          </View>
         </View>
       )}
     </Formik>
@@ -78,11 +78,7 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "space-between",
   },
-  NPbutton: {
-    width: 150,
-    borderRadius: 100,
-    padding: 10,
-    alignSelf: "center",
-    marginVertical: 10,
+  NPButtonContainer: {
+    alignItems: "center"
   },
 });

--- a/screens/CreateAccountScreen.tsx
+++ b/screens/CreateAccountScreen.tsx
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     marginHorizontal: 10,
-    marginVertical: 25,
+    marginVertical: 10,
     justifyContent: "space-between",
   },
   NPbutton: {

--- a/screens/JoinHouseholdScreen.tsx
+++ b/screens/JoinHouseholdScreen.tsx
@@ -4,6 +4,7 @@ import React, { FC, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Button, Surface, Text, TouchableRipple } from "react-native-paper";
 import * as Yup from "yup";
+import BigThemedButton from "../components/BigThemedButton";
 import ThemedTextInput from "../components/ThemedTextInput";
 import { avatars } from "../data/avatarData";
 import { Avatar } from "../interfaces/avatar";
@@ -143,17 +144,13 @@ const JoinHouseholdScreen: FC<Props> = ({ navigation }: Props) => {
               </Surface>
             </View>
           </View>
-          <Button
-            icon="plus-circle-outline"
-            mode="contained"
-            color="#fff"
-            labelStyle={styles.buttonIconSize}
-            uppercase={false}
-            style={styles.NPbutton}
+          <View style={styles.themedButtonContainer}>
+          <BigThemedButton
+            typeOfIcon="plus-circle-outline"
+            buttonText="Gå med"
             onPress={() => handleSubmit()}
-          >
-            <Text style={styles.buttonText}>Gå med</Text>
-          </Button>
+          />
+          </View>
         </View>
       )}
     </Formik>
@@ -166,11 +163,14 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     justifyContent: "space-between",
+    marginHorizontal: 10,
+    marginVertical: 10
   },
   selectAvatar: {
     alignItems: "flex-start",
     flexDirection: "column",
     marginHorizontal: 10,
+    marginVertical: 10
   },
   buttonText: {
     fontSize: 18,
@@ -213,13 +213,6 @@ const styles = StyleSheet.create({
   buttonIconSize: {
     fontSize: 25,
   },
-  NPbutton: {
-    width: 150,
-    borderRadius: 100,
-    padding: 10,
-    alignSelf: "center",
-    marginVertical: 10,
-  },
   avatarButton: {
     margin: 0,
     elevation: 0,
@@ -227,4 +220,7 @@ const styles = StyleSheet.create({
   input: {
     elevation: 4,
   },
+  themedButtonContainer: {
+    alignItems: "center"
+  }
 });

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -79,7 +79,7 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     marginHorizontal: 10,
-    marginVertical: 25,
+    marginVertical: 10,
     justifyContent: "space-between",
   },
   noAccountContainer: {

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -2,16 +2,15 @@ import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import React, { useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
 import { Modal, Portal, Provider } from "react-native-paper";
-import AddHouseholdButton from "../components/AddHouseholdButton";
 import EditHouseholdModal from "../components/EditHouseholdModal";
 import HouseholdSurface from "../components/HouseholdSurface";
-import JoinHouseholdButton from "../components/JoinHouseHoldButton";
 import { Household } from "../interfaces/households";
 import { setActiveHousholdAction, updateHouseholdAction } from "../store/household/householdSlice";
 import { RootStackParamList } from "../navigation/RootNavigator";
 import { useAppDispatch, useAppSelector } from "../store/store";
 import { isUserAdmin } from "../store/householdUser/householdUserSelectors";
 import LogoutButton from "../components/LogoutButton";
+import BigThemedButton from "../components/BigThemedButton";
 
 type Props = NativeStackScreenProps<
   RootStackParamList,
@@ -49,7 +48,11 @@ const ProfileScreen = ({ navigation }: Props) => {
   return (
     <Provider>
       <Portal>
-        <Modal visible={visible} onDismiss={() => setVisible(false)} contentContainerStyle={styles.modalStyle}>
+        <Modal
+          visible={visible}
+          onDismiss={() => setVisible(false)}
+          contentContainerStyle={styles.modalStyle}
+        >
           <EditHouseholdModal household={householdToEdit} onSubmit={onSubmit} />
         </Modal>
       </Portal>
@@ -74,11 +77,15 @@ const ProfileScreen = ({ navigation }: Props) => {
           </View>
 
           <View style={styles.NPbuttonRoot}>
-            <AddHouseholdButton
-              onAddHousehold={() => navigation.navigate("CreateHousehold")}
+            <BigThemedButton
+              typeOfIcon="plus-circle-outline"
+              buttonText="Lägg till"
+              onPress={() => navigation.navigate("CreateHousehold")}
             />
-            <JoinHouseholdButton
-              onJoinHousehold={() => navigation.navigate("JoinHousehold")}
+            <BigThemedButton
+              typeOfIcon="account-plus-outline"
+              buttonText="Gå med"
+              onPress={() => navigation.navigate("JoinHousehold")}
             />
           </View>
         </View>
@@ -93,7 +100,7 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     marginHorizontal: 10,
-    marginVertical: 25,
+    marginVertical: 10,
     justifyContent: "space-between",
   },
   NPbuttonRoot: {


### PR DESCRIPTION
closes #114 

Now all the screens with a big main button uses the reusable BigThemedButton component. Easier to refactor now when all the main buttons use the same component and with that the styling is the same on all the buttons. 

**NOTE: There were some errors in the code regarding imports, in JoinHouseholdScreen and ProfileScreen. I did not touch any of that, since I do not really know how the imports are used. But it is something to look at if the errors remain**